### PR TITLE
AddButtonの「やりたい趣味リストから削除する」メソッドを取り除きました。

### DIFF
--- a/src/components/AddButton.vue
+++ b/src/components/AddButton.vue
@@ -18,13 +18,12 @@ export default {
   methods: {
     toggleAdd() {
       if (this.isAdded) {
-        this.AddCount -= 1;
-        alert("やりたい趣味リストから削除");
+        alert("すでに追加されています");
       } else {
         this.AddCount += 1;
         alert("やりたい趣味リストに追加");
+        this.isAdded = !this.isAdded;
       }
-      this.isAdded = !this.isAdded;
     },
   },
 };


### PR DESCRIPTION
＜変更前＞AddButtonを２回を押すと追加→「削除」の流れで想定し、スタイルを切り替えていた。
＜変更後＞AddButtonを２回を押すと追加→「既に追加されています」というアラートが出るようにしました。

よろしくお願いします！