### PR TITLE
ログイン画面が元に戻りました

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -49,7 +49,7 @@ watchEffect(() => {
 </script>
 
 <template>
-  <div :class="$attrs.authWrapper">
+  <div class="authWrapper">
     <authenticator :sign-up-attributes="['nickname']" v-slot="{ signOut }">
       <Header :pageTitle="pageTitle" />
       <div class="marginHeader"></div>


### PR DESCRIPTION
App.vueのauthWrapperクラスにあったattrasの記載を消すことで元に戻りました。