### PR TITLE
画面全体のレイアウトが崩れる問題を解消

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -50,7 +50,7 @@ watchEffect(() => {
 
 <template>
   <div :class="$attrs.authWrapper">
-    <authenticator :sign-up-attributes="['nickname']" v-slot="{ signOut }">
+    <authenticator :sign-up-attributes="['nickname']" v-slot="{ signOut }" class="authWrapper">
       <Header :pageTitle="pageTitle" />
       <div class="marginHeader"></div>
       <router-view :signOut="signOut" />


### PR DESCRIPTION
$attrsをとると画面すべてのレイアウトが崩れてしまっていたのでそれを残したままauthenticatorタグにauthWrapperクラスを付与