### PR TITLE
趣味を登録できるように変更

### DIFF
--- a/src/pages/AddMyHobby.vue
+++ b/src/pages/AddMyHobby.vue
@@ -34,6 +34,7 @@
 
 <script>
 import axios from 'axios';
+import { get_user_id } from "@/util"; // ユーザーID取得の関数をインポート
 
 export default {
   data() {
@@ -72,23 +73,32 @@ export default {
       );
       this.updateAvailableHobbies();
     },
-    submitHobbies() {
-      alert("MY趣味リストを更新");
-      axios
-        .post(
-          "https://pq0br03i97.execute-api.ap-northeast-1.amazonaws.com/dev/hobby?user_id=27241a58-8041-70f7-fb7f-0ffac79afb6b&hobby_id=8"
-        )
-        .then(response => {
-          this.hobbies = response.data;
-          this.updateAvailableHobbies();
-        })
-        .catch(error => {
-          console.error("データの取得に失敗しました:", error);
-        });
+    async submitHobbies() {
+      if (this.selectedHobbies.length === 0) {
+        alert("少なくとも1つ趣味を選んでください。");
+        return;
+      }
+
+      try {
+        const userId = await get_user_id(); // ユーザーIDを取得
+        const hobbyIds = this.selectedHobbies.map(hobby => hobby.id); // 選択した趣味のIDを取得
+
+        // APIリクエストで趣味をRDSに保存
+        await axios.post(
+          "https://your-api-endpoint/hobby/save", // 実際のAPIエンドポイントに置き換えて
+          { userId, hobbyIds } // ユーザーIDと趣味IDを送信
+        );
+
+        alert("趣味リストを更新しました！");
+      } catch (error) {
+        console.error("趣味の登録に失敗しました:", error);
+        alert("趣味の登録に失敗しました。");
+      }
     },
   },
 };
 </script>
+
 
 <style scoped>
 * {


### PR DESCRIPTION
APIエンドポイントの入力はまだですが、それ以外はおそらく大丈夫です。
ユーザーIDの取得: submitHobbiesメソッド内でget_user_id()を呼び出して、ユーザーIDを取得するようにした。
趣味IDの取得: 選択した趣味のIDを配列にまとめて、APIに送信する準備をした。
選択した趣味のIDとユーザーIDを含めたデータをAPIで送信できるようにした